### PR TITLE
Add a function to retrieve an element in a list

### DIFF
--- a/com/instance_boolean_pair_list.go
+++ b/com/instance_boolean_pair_list.go
@@ -54,7 +54,7 @@ func (list *InstanceBooleanPairList) Size() int {
 
 func (list *InstanceBooleanPairList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/com/instance_boolean_pair_list.go
+++ b/com/instance_boolean_pair_list.go
@@ -52,6 +52,16 @@ func (list *InstanceBooleanPairList) Size() int {
 	return -1
 }
 
+func (list *InstanceBooleanPairList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
+}
+
 // ================================================================================
 // Defines COM InstanceBooleanPairList type as a MAL Composite
 

--- a/com/object_details_list.go
+++ b/com/object_details_list.go
@@ -54,7 +54,7 @@ func (list *ObjectDetailsList) Size() int {
 
 func (list *ObjectDetailsList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/com/object_details_list.go
+++ b/com/object_details_list.go
@@ -52,6 +52,16 @@ func (list *ObjectDetailsList) Size() int {
 	return -1
 }
 
+func (list *ObjectDetailsList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
+}
+
 // ================================================================================
 // Defines MAL ObjectDetailsList type as a MAL Composite
 

--- a/com/object_id_list.go
+++ b/com/object_id_list.go
@@ -52,6 +52,16 @@ func (list *ObjectIdList) Size() int {
 	return -1
 }
 
+func (list *ObjectIdList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
+}
+
 // ================================================================================
 // Defines MAL ObjectIdList type as a MAL Composite
 

--- a/com/object_id_list.go
+++ b/com/object_id_list.go
@@ -54,7 +54,7 @@ func (list *ObjectIdList) Size() int {
 
 func (list *ObjectIdList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/com/object_key_list.go
+++ b/com/object_key_list.go
@@ -54,7 +54,7 @@ func (list *ObjectKeyList) Size() int {
 
 func (list *ObjectKeyList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/com/object_key_list.go
+++ b/com/object_key_list.go
@@ -52,6 +52,16 @@ func (list *ObjectKeyList) Size() int {
 	return -1
 }
 
+func (list *ObjectKeyList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
+}
+
 // ================================================================================
 // Defines MAL ObjectKeyList type as a MAL Composite
 

--- a/com/object_type_list.go
+++ b/com/object_type_list.go
@@ -52,6 +52,16 @@ func (list *ObjectTypeList) Size() int {
 	return -1
 }
 
+func (list *ObjectTypeList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
+}
+
 // ================================================================================
 // Defines COM ObjectTypeList type as a MAL Composite
 

--- a/com/object_type_list.go
+++ b/com/object_type_list.go
@@ -54,7 +54,7 @@ func (list *ObjectTypeList) Size() int {
 
 func (list *ObjectTypeList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/blob_list.go
+++ b/mal/blob_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL BlobList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *BlobList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *BlobList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/blob_list.go
+++ b/mal/blob_list.go
@@ -50,7 +50,7 @@ func (list *BlobList) Size() int {
 
 func (list *BlobList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/boolean_list.go
+++ b/mal/boolean_list.go
@@ -50,7 +50,7 @@ func (list *BooleanList) Size() int {
 
 func (list *BooleanList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/boolean_list.go
+++ b/mal/boolean_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL BooleanList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *BooleanList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *BooleanList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/double_list.go
+++ b/mal/double_list.go
@@ -50,7 +50,7 @@ func (list *DoubleList) Size() int {
 
 func (list *DoubleList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/double_list.go
+++ b/mal/double_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL DoubleList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *DoubleList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *DoubleList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/duration_list.go
+++ b/mal/duration_list.go
@@ -50,7 +50,7 @@ func (list *DurationList) Size() int {
 
 func (list *DurationList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/duration_list.go
+++ b/mal/duration_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL DurationList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *DurationList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *DurationList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/element_list.go
+++ b/mal/element_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL ElementList type
 // It corresponds to a list of abstract elements.
@@ -34,4 +32,5 @@ import ()
 type ElementList interface {
 	Composite
 	Size() int
+	GetElementAt(i int) Element
 }

--- a/mal/entitykey_list.go
+++ b/mal/entitykey_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL EntityKeyList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *EntityKeyList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *EntityKeyList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/entitykey_list.go
+++ b/mal/entitykey_list.go
@@ -50,7 +50,7 @@ func (list *EntityKeyList) Size() int {
 
 func (list *EntityKeyList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/entityrequest_list.go
+++ b/mal/entityrequest_list.go
@@ -50,7 +50,7 @@ func (list *EntityRequestList) Size() int {
 
 func (list *EntityRequestList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/entityrequest_list.go
+++ b/mal/entityrequest_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL EntityRequestList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *EntityRequestList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *EntityRequestList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/file_list.go
+++ b/mal/file_list.go
@@ -50,7 +50,7 @@ func (list *FileList) Size() int {
 
 func (list *FileList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/file_list.go
+++ b/mal/file_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL FileList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *FileList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *FileList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/finetime_list.go
+++ b/mal/finetime_list.go
@@ -50,7 +50,7 @@ func (list *FineTimeList) Size() int {
 
 func (list *FineTimeList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/finetime_list.go
+++ b/mal/finetime_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL FineTimeList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *FineTimeList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *FineTimeList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/float_list.go
+++ b/mal/float_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL FloatList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *FloatList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *FloatList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/float_list.go
+++ b/mal/float_list.go
@@ -50,7 +50,7 @@ func (list *FloatList) Size() int {
 
 func (list *FloatList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/idbooleanpair_list.go
+++ b/mal/idbooleanpair_list.go
@@ -50,7 +50,7 @@ func (list *IdBooleanPairList) Size() int {
 
 func (list *IdBooleanPairList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/idbooleanpair_list.go
+++ b/mal/idbooleanpair_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL IdBooleanPairList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *IdBooleanPairList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *IdBooleanPairList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/identifier_list.go
+++ b/mal/identifier_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL IdentifierList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *IdentifierList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *IdentifierList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/identifier_list.go
+++ b/mal/identifier_list.go
@@ -50,7 +50,7 @@ func (list *IdentifierList) Size() int {
 
 func (list *IdentifierList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/integer_list.go
+++ b/mal/integer_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL IntegerList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *IntegerList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *IntegerList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/integer_list.go
+++ b/mal/integer_list.go
@@ -50,7 +50,7 @@ func (list *IntegerList) Size() int {
 
 func (list *IntegerList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/long_list.go
+++ b/mal/long_list.go
@@ -50,7 +50,7 @@ func (list *LongList) Size() int {
 
 func (list *LongList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/long_list.go
+++ b/mal/long_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL LongList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *LongList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *LongList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/namedvalue_list.go
+++ b/mal/namedvalue_list.go
@@ -50,7 +50,7 @@ func (list *NamedValueList) Size() int {
 
 func (list *NamedValueList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/namedvalue_list.go
+++ b/mal/namedvalue_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL NamedValueList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *NamedValueList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *NamedValueList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/octet_list.go
+++ b/mal/octet_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL OctetList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *OctetList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *OctetList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/octet_list.go
+++ b/mal/octet_list.go
@@ -50,7 +50,7 @@ func (list *OctetList) Size() int {
 
 func (list *OctetList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/pair_list.go
+++ b/mal/pair_list.go
@@ -50,7 +50,7 @@ func (list *PairList) Size() int {
 
 func (list *PairList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/pair_list.go
+++ b/mal/pair_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL PairList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *PairList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *PairList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/short_list.go
+++ b/mal/short_list.go
@@ -50,7 +50,7 @@ func (list *ShortList) Size() int {
 
 func (list *ShortList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/short_list.go
+++ b/mal/short_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL ShortList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *ShortList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *ShortList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/string_list.go
+++ b/mal/string_list.go
@@ -50,7 +50,7 @@ func (list *StringList) Size() int {
 
 func (list *StringList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/string_list.go
+++ b/mal/string_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL StringList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *StringList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *StringList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/subscription_list.go
+++ b/mal/subscription_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL SubscriptionList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *SubscriptionList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *SubscriptionList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/subscription_list.go
+++ b/mal/subscription_list.go
@@ -50,7 +50,7 @@ func (list *SubscriptionList) Size() int {
 
 func (list *SubscriptionList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/time_list.go
+++ b/mal/time_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL TimeList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *TimeList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *TimeList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/time_list.go
+++ b/mal/time_list.go
@@ -50,7 +50,7 @@ func (list *TimeList) Size() int {
 
 func (list *TimeList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/uinteger_list.go
+++ b/mal/uinteger_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL UIntegerList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *UIntegerList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *UIntegerList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/uinteger_list.go
+++ b/mal/uinteger_list.go
@@ -50,7 +50,7 @@ func (list *UIntegerList) Size() int {
 
 func (list *UIntegerList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/ulong_list.go
+++ b/mal/ulong_list.go
@@ -50,7 +50,7 @@ func (list *ULongList) Size() int {
 
 func (list *ULongList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/ulong_list.go
+++ b/mal/ulong_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL ULongList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *ULongList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *ULongList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/uoctet_list.go
+++ b/mal/uoctet_list.go
@@ -50,7 +50,7 @@ func (list *UOctetList) Size() int {
 
 func (list *UOctetList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/uoctet_list.go
+++ b/mal/uoctet_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL UOctetList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *UOctetList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *UOctetList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/updateheader_list.go
+++ b/mal/updateheader_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL UpdateHeaderList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *UpdateHeaderList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *UpdateHeaderList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/updateheader_list.go
+++ b/mal/updateheader_list.go
@@ -50,7 +50,7 @@ func (list *UpdateHeaderList) Size() int {
 
 func (list *UpdateHeaderList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/uri_list.go
+++ b/mal/uri_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL URIList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *URIList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *URIList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================

--- a/mal/uri_list.go
+++ b/mal/uri_list.go
@@ -50,7 +50,7 @@ func (list *URIList) Size() int {
 
 func (list *URIList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/ushort_list.go
+++ b/mal/ushort_list.go
@@ -50,7 +50,7 @@ func (list *UShortList) Size() int {
 
 func (list *UShortList) GetElementAt(i int) Element {
 	if list != nil {
-		if i <= list.Size() {
+		if i < list.Size() {
 			return (*list)[i]
 		}
 		return nil

--- a/mal/ushort_list.go
+++ b/mal/ushort_list.go
@@ -23,8 +23,6 @@
  */
 package mal
 
-import ()
-
 // ################################################################################
 // Defines MAL UShortList type
 // ################################################################################
@@ -48,6 +46,16 @@ func (list *UShortList) Size() int {
 		return len(*list)
 	}
 	return -1
+}
+
+func (list *UShortList) GetElementAt(i int) Element {
+	if list != nil {
+		if i <= list.Size() {
+			return (*list)[i]
+		}
+		return nil
+	}
+	return nil
 }
 
 // ================================================================================


### PR DESCRIPTION
This pull request adds a new function in the interface **ElementList**. This function allows to retrieve an element in a list. Here is the new interface:
```
type ElementList interface {
	Composite
	Size() int
	GetElementAt(i int) Element
}
```
It required to implement this function for each element that extends ElementList. Here is an example for the type **DurationList**:
```
func (list *DurationList) GetElementAt(i int) Element {
	if list != nil {
		if i <= list.Size() {
			return (*list)[i]
		}
		return nil
	}
	return nil
}
```